### PR TITLE
The property cannot be processed because the property "Guid" already exists.

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -166,12 +166,22 @@ try {
     #region Calulate action
     $actionMessage = "calculating action"
 
+    $account = [PSCustomObject]$actionContext.Data.PsObject.Copy()
+
+    # Remove properties of account object with null-values
+    $account.PsObject.Properties | ForEach-Object {
+        # Remove properties with null-values
+        if ($_.Value -eq $null) {
+            $account.PsObject.Properties.Remove("$($_.Name)")
+        }
+    }
+
     if (($correlatedAccount | Measure-Object).count -eq 1) {
-        $accountPropertiesToCompare = $actionContext.Data | Get-Member -MemberType Properties | Select-Object -ExpandProperty Name
+        $accountPropertiesToCompare = $account | Get-Member -MemberType Properties | Select-Object -ExpandProperty Name
 
         $accountSplatCompareProperties = @{
             ReferenceObject  = $correlatedAccount.PSObject.Properties | Where-Object { $_.Name -in $accountPropertiesToCompare }
-            DifferenceObject = $actionContext.Data.PSObject.Properties | Where-Object { $_.Name -in $accountPropertiesToCompare }
+            DifferenceObject = $account.PSObject.Properties | Where-Object { $_.Name -in $accountPropertiesToCompare }
         }
 
         if ($null -ne $accountSplatCompareProperties.ReferenceObject -and $null -ne $accountSplatCompareProperties.DifferenceObject) {

--- a/update.ps1
+++ b/update.ps1
@@ -147,7 +147,7 @@ try {
     # Docs: https://learn.microsoft.com/en-us/powershell/module/exchange/get-user?view=exchange-ps
     $actionMessage = "querying account where [Identity] = [$($actionContext.References.Account)]"
 
-    $accountPropertiesToQuery = @("Guid", "DisplayName") + $actionContext.Data.PsObject.Properties.Name | Select-Object -Unique
+    $accountPropertiesToQuery = @("guid", "DisplayName") + $actionContext.Data.PsObject.Properties.Name | Select-Object -Unique
 
     $getMicrosoftExchangeOnlineAccountSplatParams = @{
         Identity    = $actionContext.References.Account


### PR DESCRIPTION
# Case
We're currently working on implementing HelloID auto provisioning. We're currently running into a issue when trying to provision users on the exchange online target using the `correlateOnly` create script (But as far as I can tell this also happens with the normal create script). We're getting the following error:

`The property cannot be processed because the property "Guid" already exists.`

This seems to happen because `$actionContext.Data` contains `guid=` so when comparing old and new values you will end up with the following difference:
`OldValues": { "Guid": "df62094c-df3b-4ab1-8c2a-524030161ae3"}`
`NewValues": { "guid": null }`

With there no `Guid` parameter existing on the `Set-Mailbox` function this throws an error.

# Given solution
I've taken a page from the book of the [Entra Target connector](https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-EntraID/blob/main/update.ps1#L125). Though I still believe this is a less than ideal solution.

# Ideal solution
Ideally the data that's transferred over from the create script to the update script should be filled properly. So that when comparing changes only the actually changed relevant fields get updated and so that you actually get the functionality to empty fields where necessary.